### PR TITLE
Add incremental make/unmake move support for perft

### DIFF
--- a/Board.h
+++ b/Board.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "board.h"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	g++ -std=c++17 -Wall -Wextra Board.cpp MoveGen.cpp main.cpp -o c
+	g++ -std=c++17 -Wall -Wextra board.cpp MoveGen.cpp main.cpp -o c
 
 clean:
 	rm -f c chess *.exe

--- a/MoveGen.cpp
+++ b/MoveGen.cpp
@@ -150,6 +150,104 @@ void MoveGen::applyMove(Board &board, Move &move)
     board.whiteToMove = !board.whiteToMove;
 }
 
+void MoveGen::makeMove(Board &board, Move &move, MoveState &state)
+{
+    state.castlingRights[WHITEKING] = board.castlingRights[WHITEKING];
+    state.castlingRights[WHITEQUEEN] = board.castlingRights[WHITEQUEEN];
+    state.castlingRights[BLACKKING] = board.castlingRights[BLACKKING];
+    state.castlingRights[BLACKQUEEN] = board.castlingRights[BLACKQUEEN];
+    state.enPassantSquare = board.enPassantSquare;
+    state.movesSinceCapture = board.movesSinceCapture;
+    state.moves = board.moves;
+    state.whiteToMove = board.whiteToMove;
+    state.capturedPiece = NONE;
+    state.capturedColor = BOTH;
+    state.capturedSquare = -1;
+
+    Color opp = (move.color == WHITE) ? BLACK : WHITE;
+
+    if (move.isEnPassant)
+    {
+        state.capturedPiece = PAWN;
+        state.capturedColor = opp;
+        state.capturedSquare = (move.color == WHITE) ? (move.to - 8) : (move.to + 8);
+    }
+    else if (move.isCapture)
+    {
+        auto [capPiece, capColor] = board.findPiece(move.to);
+        state.capturedPiece = capPiece;
+        state.capturedColor = capColor;
+        state.capturedSquare = move.to;
+    }
+
+    applyMove(board, move);
+}
+
+void MoveGen::unmakeMove(Board &board, const Move &move, const MoveState &state)
+{
+    int from = move.from;
+    int to = move.to;
+    Piece piece = move.piece;
+    Color color = move.color;
+
+    if (move.isCastle)
+    {
+        if (color == WHITE)
+        {
+            if (to == 6)
+            {
+                board.clearSquare(KING, WHITE, 6);
+                board.setPiece(KING, WHITE, 4);
+                board.clearSquare(ROOK, WHITE, 5);
+                board.setPiece(ROOK, WHITE, 7);
+            }
+            else if (to == 2)
+            {
+                board.clearSquare(KING, WHITE, 2);
+                board.setPiece(KING, WHITE, 4);
+                board.clearSquare(ROOK, WHITE, 3);
+                board.setPiece(ROOK, WHITE, 0);
+            }
+        }
+        else
+        {
+            if (to == 62)
+            {
+                board.clearSquare(KING, BLACK, 62);
+                board.setPiece(KING, BLACK, 60);
+                board.clearSquare(ROOK, BLACK, 61);
+                board.setPiece(ROOK, BLACK, 63);
+            }
+            else if (to == 58)
+            {
+                board.clearSquare(KING, BLACK, 58);
+                board.setPiece(KING, BLACK, 60);
+                board.clearSquare(ROOK, BLACK, 59);
+                board.setPiece(ROOK, BLACK, 56);
+            }
+        }
+    }
+    else
+    {
+        board.clearSquare(piece, color, to);
+        board.setPiece(piece, color, from);
+    }
+
+    if (state.capturedPiece != NONE)
+    {
+        board.setPiece(state.capturedPiece, state.capturedColor, state.capturedSquare);
+    }
+
+    board.castlingRights[WHITEKING] = state.castlingRights[WHITEKING];
+    board.castlingRights[WHITEQUEEN] = state.castlingRights[WHITEQUEEN];
+    board.castlingRights[BLACKKING] = state.castlingRights[BLACKKING];
+    board.castlingRights[BLACKQUEEN] = state.castlingRights[BLACKQUEEN];
+    board.enPassantSquare = state.enPassantSquare;
+    board.movesSinceCapture = state.movesSinceCapture;
+    board.moves = state.moves;
+    board.whiteToMove = state.whiteToMove;
+}
+
 void MoveGen::initAttackTables()
 {
     initPawnAttacks();

--- a/MoveGen.h
+++ b/MoveGen.h
@@ -2,6 +2,20 @@
 #pragma once
 
 #include "Board.h"
+#include <array>
+
+struct MoveState
+{
+    std::array<bool, 4> castlingRights{};
+    int enPassantSquare = -1;
+    int movesSinceCapture = 0;
+    int moves = 0;
+    bool whiteToMove = true;
+    Piece capturedPiece = NONE;
+    Color capturedColor = BOTH;
+    int capturedSquare = -1;
+};
+
 class MoveGen
 {
 public:
@@ -12,6 +26,8 @@ public:
     static void generateQueenMoves(const Board &board, std::vector<Move> &moves);
     static void generateKingMoves(const Board &board, std::vector<Move> &moves);
     static void applyMove(Board &board, Move &move);
+    static void makeMove(Board &board, Move &move, MoveState &state);
+    static void unmakeMove(Board &board, const Move &move, const MoveState &state);
     static void initAttackTables();
     static void generatePseudoLegalMoves(const Board &board, std::vector<Move> &moves);
     static void generateLegalMoves(const Board &board, std::vector<Move> &moves);

--- a/Movegen.h
+++ b/Movegen.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "MoveGen.h"

--- a/main.cpp
+++ b/main.cpp
@@ -3,9 +3,7 @@
 #include <iostream>
 #include <chrono>
 
-// TODO: Optimization: make / unmake moves to avoid copying board for every move
-
-uint64_t perft(Board board, int depth, MoveGen &moveGen)
+uint64_t perft(Board &board, int depth, MoveGen &moveGen)
 {
     if (depth == 0)
         return 1ULL;
@@ -16,9 +14,10 @@ uint64_t perft(Board board, int depth, MoveGen &moveGen)
     uint64_t nodes = 0ULL;
     for (auto &m : moves)
     {
-        Board newBoard = board;
-        moveGen.applyMove(newBoard, m);
-        nodes += perft(newBoard, depth - 1, moveGen);
+        MoveState state;
+        MoveGen::makeMove(board, m, state);
+        nodes += perft(board, depth - 1, moveGen);
+        MoveGen::unmakeMove(board, m, state);
     }
     return nodes;
 }
@@ -31,9 +30,10 @@ void perftTest(Board &board, int depth, MoveGen &moveGen)
     uint64_t total = 0ULL;
     for (auto &m : moves)
     {
-        Board newBoard = board;
-        moveGen.applyMove(newBoard, m);
-        uint64_t count = perft(newBoard, depth - 1, moveGen);
+        MoveState state;
+        MoveGen::makeMove(board, m, state);
+        uint64_t count = perft(board, depth - 1, moveGen);
+        MoveGen::unmakeMove(board, m, state);
         total += count;
     }
     std::cout << "Total nodes at depth " << depth << ": " << total << "\n";


### PR DESCRIPTION
## Summary
- introduce a MoveState helper along with make/unmake move helpers to reuse board state during perft
- switch perft recursion to use incremental move application instead of copying boards and add compatibility headers for existing includes
