### PR TITLE
Avoid board copies during legal move generation

### DIFF
--- a/Board.h
+++ b/Board.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "board.h"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	g++ -std=c++17 -Wall -Wextra Board.cpp MoveGen.cpp main.cpp -o c
+	g++ -std=c++17 -Wall -Wextra board.cpp MoveGen.cpp main.cpp -o c
 
 clean:
 	rm -f c chess *.exe

--- a/MoveGen.h
+++ b/MoveGen.h
@@ -2,6 +2,20 @@
 #pragma once
 
 #include "Board.h"
+#include <array>
+
+struct MoveState
+{
+    std::array<bool, 4> castlingRights{};
+    int enPassantSquare = -1;
+    int movesSinceCapture = 0;
+    int moves = 0;
+    bool whiteToMove = true;
+    Piece capturedPiece = NONE;
+    Color capturedColor = BOTH;
+    int capturedSquare = -1;
+};
+
 class MoveGen
 {
 public:
@@ -12,9 +26,11 @@ public:
     static void generateQueenMoves(const Board &board, std::vector<Move> &moves);
     static void generateKingMoves(const Board &board, std::vector<Move> &moves);
     static void applyMove(Board &board, Move &move);
+    static void makeMove(Board &board, Move &move, MoveState &state);
+    static void unmakeMove(Board &board, const Move &move, const MoveState &state);
     static void initAttackTables();
     static void generatePseudoLegalMoves(const Board &board, std::vector<Move> &moves);
-    static void generateLegalMoves(const Board &board, std::vector<Move> &moves);
+    static void generateLegalMoves(Board &board, std::vector<Move> &moves);
     static bool isSquareAttacked(const Board &board, int sq, Color attacker);
     static void printAttackMap(const Board &board, Color attacker);
 

--- a/Movegen.h
+++ b/Movegen.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "MoveGen.h"

--- a/main.cpp
+++ b/main.cpp
@@ -3,9 +3,7 @@
 #include <iostream>
 #include <chrono>
 
-// TODO: Optimization: make / unmake moves to avoid copying board for every move
-
-uint64_t perft(Board board, int depth, MoveGen &moveGen)
+uint64_t perft(Board &board, int depth, MoveGen &moveGen)
 {
     if (depth == 0)
         return 1ULL;
@@ -16,9 +14,10 @@ uint64_t perft(Board board, int depth, MoveGen &moveGen)
     uint64_t nodes = 0ULL;
     for (auto &m : moves)
     {
-        Board newBoard = board;
-        moveGen.applyMove(newBoard, m);
-        nodes += perft(newBoard, depth - 1, moveGen);
+        MoveState state;
+        MoveGen::makeMove(board, m, state);
+        nodes += perft(board, depth - 1, moveGen);
+        MoveGen::unmakeMove(board, m, state);
     }
     return nodes;
 }
@@ -31,9 +30,10 @@ void perftTest(Board &board, int depth, MoveGen &moveGen)
     uint64_t total = 0ULL;
     for (auto &m : moves)
     {
-        Board newBoard = board;
-        moveGen.applyMove(newBoard, m);
-        uint64_t count = perft(newBoard, depth - 1, moveGen);
+        MoveState state;
+        MoveGen::makeMove(board, m, state);
+        uint64_t count = perft(board, depth - 1, moveGen);
+        MoveGen::unmakeMove(board, m, state);
         total += count;
     }
     std::cout << "Total nodes at depth " << depth << ": " << total << "\n";


### PR DESCRIPTION
## Summary
- reuse make/unmake when filtering pseudo-legal moves so validation no longer copies the board
- update the generateLegalMoves signature to accept a mutable board reference so it can be restored via MoveState